### PR TITLE
Fail early

### DIFF
--- a/pkg/Listener/UDPListener.go
+++ b/pkg/Listener/UDPListener.go
@@ -41,11 +41,6 @@ func (l *UDPListener) respond(b []byte, addr net.Addr, conn *net.UDPConn) {
 	dnsPacket := packet.Layer(layers.LayerTypeDNS)
 	tcp, _ := dnsPacket.(*layers.DNS)
 	answer := l.Factory.BuildResponse(tcp)
-	if answer.ANCount == 0 {
-		//TODO: implement and use request tracing
-		log.Info("Unable to find any answer for request, ignoring query.")
-		return
-	}
 	buf := gopacket.NewSerializeBuffer()
 	o := gopacket.SerializeOptions{}
 	err := answer.SerializeTo(buf, o)


### PR DESCRIPTION
When we receive questions for which we can't build answers, set the appropriate response code and
reply immediately without processing further questions. This is done to avoid situations where we
encounter multiple questions that we can't build answers for for different reasons but can only
respond with a single response code.